### PR TITLE
Initialize React Native skeleton

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import AppNavigator from './src/navigation/AppNavigator';
+
+export default function App() {
+  return (
+    <RecoilRoot>
+      <AppNavigator />
+    </RecoilRoot>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # app-client
+
+This project is a React Native client for creating custom fan designs (推しうちわ). The current codebase contains a minimal skeleton with TypeScript, React Navigation, Recoil, and i18n setup.
+
+## Development
+
+```sh
+npm install
+npm run start
+```
+
+No tests are configured yet.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "app-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17",
+    "axios": "^1.5.0",
+    "i18n-js": "^4.3.0",
+    "react": "18.2.0",
+    "react-native": "0.73.7",
+    "react-native-gesture-handler": "^2.12.0",
+    "react-native-reanimated": "^3.6.2",
+    "react-native-safe-area-context": "^4.8.1",
+    "react-native-screens": "^3.22.0",
+    "recoil": "^0.7.7"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/atoms/design.ts
+++ b/src/atoms/design.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+export interface DesignData {
+  id: string;
+  name: string;
+  elements: any[]; // TODO: define element types
+}
+
+export const designState = atom<DesignData[]>({
+  key: 'designState',
+  default: [],
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,19 @@
+import { I18n } from 'i18n-js';
+import * as Localization from 'expo-localization';
+
+const translations = {
+  en: {
+    home_title: 'My Designs',
+    new_design: 'Create New',
+  },
+  ja: {
+    home_title: '保存済みデザイン',
+    new_design: '新規作成',
+  },
+};
+
+const i18n = new I18n(translations);
+i18n.locale = Localization.locale;
+i18n.enableFallback = true;
+
+export default i18n;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from '@screens/HomeScreen';
+import EditorScreen from '@screens/EditorScreen';
+import GuideScreen from '@screens/GuideScreen';
+import PreviewScreen from '@screens/PreviewScreen';
+import ARPreviewScreen from '@screens/ARPreviewScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Editor: undefined;
+  Guide: undefined;
+  Preview: undefined;
+  ARPreview: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function AppNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Editor" component={EditorScreen} />
+        <Stack.Screen name="Guide" component={GuideScreen} />
+        <Stack.Screen name="Preview" component={PreviewScreen} />
+        <Stack.Screen name="ARPreview" component={ARPreviewScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/screens/ARPreviewScreen.tsx
+++ b/src/screens/ARPreviewScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function ARPreviewScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>AR Preview Screen (WIP)</Text>
+    </View>
+  );
+}

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function EditorScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Editor Screen (WIP)</Text>
+    </View>
+  );
+}

--- a/src/screens/GuideScreen.tsx
+++ b/src/screens/GuideScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function GuideScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Guide Screen (WIP)</Text>
+    </View>
+  );
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useRecoilValue } from 'recoil';
+import { designState } from '@atoms/design';
+import i18n from '@i18n/index';
+
+export default function HomeScreen() {
+  const navigation = useNavigation();
+  const designs = useRecoilValue(designState);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 24, marginBottom: 16 }}>{i18n.t('home_title')}</Text>
+      <FlatList
+        data={designs}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <Text>{item.name}</Text>}
+      />
+      <Button
+        title={i18n.t('new_design')}
+        onPress={() => navigation.navigate('Editor' as never)}
+      />
+    </View>
+  );
+}

--- a/src/screens/PreviewScreen.tsx
+++ b/src/screens/PreviewScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function PreviewScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Preview Screen (WIP)</Text>
+    </View>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "jsx": "react",
+    "strict": true,
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["react", "react-native"],
+    "baseUrl": "./",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@screens/*": ["src/screens/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@utils/*": ["src/utils/*"],
+      "@services/*": ["src/services/*"],
+      "@navigation/*": ["src/navigation/*"],
+      "@atoms/*": ["src/atoms/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup TypeScript React Native project skeleton
- add Recoil atom for design data
- add basic i18n configuration
- implement stack navigator and placeholder screens
- include README instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb32c5758832ba12fecbfe4516511