### PR TITLE
Add expo-localization dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native-stack": "^6.9.17",
     "axios": "^1.5.0",
     "i18n-js": "^4.3.0",
+    "expo-localization": "^15.0.0",
     "react": "18.2.0",
     "react-native": "0.73.7",
     "react-native-gesture-handler": "^2.12.0",


### PR DESCRIPTION
## Summary
- add `expo-localization` so the i18n setup imports properly

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb6d0b77c832bb815484be56f71b7