### PR TITLE
Add settings screen with Recoil state

### DIFF
--- a/src/atoms/settings.ts
+++ b/src/atoms/settings.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+export const languageState = atom<string>({
+  key: 'languageState',
+  default: 'en',
+});
+
+export const darkModeState = atom<boolean>({
+  key: 'darkModeState',
+  default: false,
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,10 +5,16 @@ const translations = {
   en: {
     home_title: 'My Designs',
     new_design: 'Create New',
+    settings_title: 'Settings',
+    language: 'Language',
+    dark_mode: 'Dark Mode',
   },
   ja: {
     home_title: '保存済みデザイン',
     new_design: '新規作成',
+    settings_title: '設定',
+    language: '言語',
+    dark_mode: 'ダークモード',
   },
 };
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -7,6 +7,7 @@ import EditorScreen from '@screens/EditorScreen';
 import GuideScreen from '@screens/GuideScreen';
 import PreviewScreen from '@screens/PreviewScreen';
 import ARPreviewScreen from '@screens/ARPreviewScreen';
+import SettingsScreen from '@screens/SettingsScreen';
 
 export type RootStackParamList = {
   Home: undefined;
@@ -14,6 +15,7 @@ export type RootStackParamList = {
   Guide: undefined;
   Preview: undefined;
   ARPreview: undefined;
+  Settings: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -28,6 +30,7 @@ export default function AppNavigator() {
         <Stack.Screen name="Guide" component={GuideScreen} />
         <Stack.Screen name="Preview" component={PreviewScreen} />
         <Stack.Screen name="ARPreview" component={ARPreviewScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, Switch, Button } from 'react-native';
+import { useRecoilState } from 'recoil';
+import { languageState, darkModeState } from '@atoms/settings';
+import i18n from '@i18n/index';
+
+export default function SettingsScreen() {
+  const [language, setLanguage] = useRecoilState(languageState);
+  const [darkMode, setDarkMode] = useRecoilState(darkModeState);
+
+  const toggleLanguage = () => {
+    const newLang = language === 'en' ? 'ja' : 'en';
+    setLanguage(newLang);
+    i18n.locale = newLang;
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 24, marginBottom: 16 }}>{i18n.t('settings_title')}</Text>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <Text>{i18n.t('language')}</Text>
+        <Button title={language.toUpperCase()} onPress={toggleLanguage} />
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Text>{i18n.t('dark_mode')}</Text>
+        <Switch value={darkMode} onValueChange={setDarkMode} />
+      </View>
+    </View>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@utils/*": ["src/utils/*"],
       "@services/*": ["src/services/*"],
       "@navigation/*": ["src/navigation/*"],
-      "@atoms/*": ["src/atoms/*"]
+      "@atoms/*": ["src/atoms/*"],
+      "@i18n/*": ["src/i18n/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary
- support configuring app settings
- store `language` and `darkMode` selections in Recoil atoms
- allow toggling language and dark mode from new Settings screen
- update translations to include settings text
- update stack navigator and path aliases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb6d90680832bb24ffc813281694d