### PR TITLE
Add offline storage hook

### DIFF
--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function useOfflineStorage<T>(key: string) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(key);
+        if (stored) {
+          setData(JSON.parse(stored) as T);
+        }
+      } catch (err) {
+        console.error('Failed to load data', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [key]);
+
+  const save = async (value: T) => {
+    try {
+      await AsyncStorage.setItem(key, JSON.stringify(value));
+      setData(value);
+    } catch (err) {
+      console.error('Failed to save data', err);
+    }
+  };
+
+  return { data, save, loading } as const;
+}


### PR DESCRIPTION
## Summary
- add a new hook `useOfflineStorage` for saving/retrieving data via AsyncStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb6d941b0832b9dcd23b2e762da56