### PR TITLE
Implement size selection modal

### DIFF
--- a/src/components/SizeSelectorModal.tsx
+++ b/src/components/SizeSelectorModal.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, Button, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
+
+export type ShapeType = 'circle' | 'rectangle' | 'custom';
+
+interface SizeSelectorModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (params: { shape: ShapeType; width: number; height: number }) => void;
+}
+
+export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSelectorModalProps) {
+  const [shape, setShape] = useState<ShapeType>('circle');
+  const [width, setWidth] = useState('300');
+  const [height, setHeight] = useState('300');
+
+  const handleSelect = () => {
+    const w = parseInt(width, 10) || 0;
+    const h = parseInt(height, 10) || 0;
+    onSelect({ shape, width: w, height: h });
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.overlay}>
+        <View style={styles.modal}>
+          <Text style={styles.title}>Select Size</Text>
+          <View style={styles.shapes}>
+            <TouchableOpacity
+              style={[styles.shapeButton, shape === 'circle' && styles.active]}
+              onPress={() => setShape('circle')}
+            >
+              <Text>Circle</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.shapeButton, shape === 'rectangle' && styles.active]}
+              onPress={() => setShape('rectangle')}
+            >
+              <Text>Rectangle</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.shapeButton, shape === 'custom' && styles.active]}
+              onPress={() => setShape('custom')}
+            >
+              <Text>Custom</Text>
+            </TouchableOpacity>
+          </View>
+          <View style={styles.inputs}>
+            <TextInput
+              style={styles.input}
+              keyboardType="numeric"
+              value={width}
+              onChangeText={setWidth}
+              placeholder="Width"
+            />
+            <TextInput
+              style={styles.input}
+              keyboardType="numeric"
+              value={height}
+              onChangeText={setHeight}
+              placeholder="Height"
+            />
+          </View>
+          <View style={styles.actions}>
+            <Button title="Cancel" onPress={onClose} />
+            <Button title="Create" onPress={handleSelect} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    width: '80%',
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 8,
+  },
+  title: { fontSize: 18, marginBottom: 12, textAlign: 'center' },
+  shapes: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 12 },
+  shapeButton: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+  },
+  active: { backgroundColor: '#def' },
+  inputs: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginHorizontal: 4,
+  },
+  actions: { flexDirection: 'row', justifyContent: 'space-between' },
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -10,7 +10,14 @@ import SettingsScreen from '@screens/SettingsScreen';
 
 export type RootStackParamList = {
   Home: undefined;
-  Editor: { id?: string } | undefined;
+  Editor:
+    | {
+        id?: string;
+        shape?: 'circle' | 'rectangle' | 'custom';
+        width?: number;
+        height?: number;
+      }
+    | undefined;
   Guide: undefined;
   Preview: undefined;
   ARPreview: undefined;

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Image, StyleSheet, Button, ActivityIndicator } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+  Button,
+  ActivityIndicator,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@navigation/AppNavigator';
+import SizeSelectorModal, { ShapeType } from '@components/SizeSelectorModal';
 
 interface DesignItem {
   id: string;
@@ -15,6 +25,7 @@ export default function DashboardScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [designs, setDesigns] = useState<DesignItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
     const fetchDesigns = async () => {
@@ -31,6 +42,11 @@ export default function DashboardScreen() {
 
     fetchDesigns();
   }, []);
+
+  const handleCreate = (params: { shape: ShapeType; width: number; height: number }) => {
+    setModalVisible(false);
+    navigation.navigate('Editor', params);
+  };
 
   const renderItem = ({ item }: { item: DesignItem }) => (
     <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('Editor', { id: item.id })}>
@@ -53,8 +69,13 @@ export default function DashboardScreen() {
         />
       )}
       <View style={styles.createButton}>
-        <Button title="Create New Design" onPress={() => navigation.navigate('Editor')} />
+        <Button title="Create New Design" onPress={() => setModalVisible(true)} />
       </View>
+      <SizeSelectorModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        onSelect={handleCreate}
+      />
     </View>
   );
 }

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -8,7 +8,7 @@ type EditorRouteProp = RouteProp<RootStackParamList, 'Editor'>;
 
 export default function EditorScreen() {
   const route = useRoute<EditorRouteProp>();
-  const { id } = route.params || {};
+  const { id, shape, width, height } = route.params || {};
 
   const onImageSelected = (uri: string) => {
     console.log('Selected image:', uri);
@@ -54,6 +54,11 @@ export default function EditorScreen() {
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>Editor Screen</Text>
       {id && <Text>Design ID: {id}</Text>}
+      {shape && (
+        <Text>
+          Shape: {shape} ({width}x{height})
+        </Text>
+      )}
       <Button title="Add Image" onPress={handleAddImage} />
     </View>
   );


### PR DESCRIPTION
## Summary
- add `SizeSelectorModal` component with shape and dimension inputs
- open size selection modal from dashboard when creating a new design
- pass shape, width and height params to Editor screen
- display selected size in Editor
- extend navigation params to include shape and size

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react' and 'react-native')*

------
https://chatgpt.com/codex/tasks/task_e_686bba0d8f04832b9556702036e1286c