### PR TITLE
Add bead guide tests and Jest setup

### DIFF
--- a/__tests__/beadGuide.test.ts
+++ b/__tests__/beadGuide.test.ts
@@ -1,0 +1,18 @@
+import { calculateBeadGuide } from '../src/utils/beadGuide';
+
+describe('calculateBeadGuide', () => {
+  it('calculates guide for simple canvas', () => {
+    const guide = calculateBeadGuide(10, 10, 1);
+    expect(guide).toEqual({ rows: 10, columns: 10, neededBeads: 100, packs: 1 });
+  });
+
+  it('rounds down rows and columns', () => {
+    const guide = calculateBeadGuide(30.5, 40.2, 5);
+    expect(guide).toEqual({ rows: 8, columns: 6, neededBeads: 48, packs: 1 });
+  });
+
+  it('calculates multiple packs when needed', () => {
+    const guide = calculateBeadGuide(100, 100, 1);
+    expect(guide.packs).toBe(10);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "test": "echo \"No tests configured\""
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.9",
@@ -26,6 +26,9 @@
     "expo-image-picker": "^15.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest, ts-jest and @types/jest as dev dependencies
- configure Jest and create `__tests__` directory
- add tests for `calculateBeadGuide`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbc42bc20832b8afae021abed8c43