### PR TITLE
Add SizeSelectorModal with defaults

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,16 @@
+name: Commit Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Node.js dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# React Native specific
+.android/
+.ios/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+

--- a/README.md
+++ b/README.md
@@ -9,5 +9,18 @@ This project is a React Native client for creating custom fan designs (推しう
 ```sh
 npm install
 npm run start
+npm test
 ```
+
+Run `npm test` after installing dependencies to execute the Jest test suite.
+
+## Commit Message Guidelines
+
+Summarize your changes in the commit message. Use a short prefix such as `feat`, `fix`, or `docs` followed by a brief description of what was done, for example:
+
+```text
+feat: implement size selector modal
+```
+
+Commit messages are checked in CI with [commitlint](https://commitlint.js.org/).
 

--- a/__tests__/beadGuide.test.ts
+++ b/__tests__/beadGuide.test.ts
@@ -1,0 +1,18 @@
+import { calculateBeadGuide } from '../src/utils/beadGuide';
+
+describe('calculateBeadGuide', () => {
+  it('calculates guide for simple canvas', () => {
+    const guide = calculateBeadGuide(10, 10, 1);
+    expect(guide).toEqual({ rows: 10, columns: 10, neededBeads: 100, packs: 1 });
+  });
+
+  it('rounds down rows and columns', () => {
+    const guide = calculateBeadGuide(30.5, 40.2, 5);
+    expect(guide).toEqual({ rows: 8, columns: 6, neededBeads: 48, packs: 1 });
+  });
+
+  it('calculates multiple packs when needed', () => {
+    const guide = calculateBeadGuide(100, 100, 1);
+    expect(guide.packs).toBe(10);
+  });
+});

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+};

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.2",
     "@types/react": "^18.2.48",
-    "@types/react-native": "^0.73.11"
+    "@types/react-native": "^0.73.11",
+    "@commitlint/cli": "^18.4.0",
+    "@commitlint/config-conventional": "^18.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "test": "echo \"No tests configured\""
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.9",
@@ -26,6 +26,11 @@
     "expo-image-picker": "^15.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.2",
+    "@types/react": "^18.2.48",
+    "@types/react-native": "^0.73.11"
   }
 }

--- a/src/components/SizeSelectorModal.tsx
+++ b/src/components/SizeSelectorModal.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, Button, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+
+export type ShapeOption = 'circle' | 'rectangle' | 'custom';
+
+interface SizeSelectorModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (shape: ShapeOption, width: number, height: number) => void;
+}
+
+const DEFAULT_CIRCLE_SIZE = 200;
+const DEFAULT_RECT_WIDTH = 200;
+const DEFAULT_RECT_HEIGHT = 150;
+
+export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSelectorModalProps) {
+  const [shape, setShape] = useState<ShapeOption>('circle');
+  const [width, setWidth] = useState('');
+  const [height, setHeight] = useState('');
+
+  const handleSelect = () => {
+    if (shape === 'circle') {
+      onSelect('circle', DEFAULT_CIRCLE_SIZE, DEFAULT_CIRCLE_SIZE);
+    } else if (shape === 'rectangle') {
+      onSelect('rectangle', DEFAULT_RECT_WIDTH, DEFAULT_RECT_HEIGHT);
+    } else {
+      const w = parseInt(width, 10) || 0;
+      const h = parseInt(height, 10) || 0;
+      onSelect('custom', w, h);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>Select Size</Text>
+          <View style={styles.options}>
+            {(['circle', 'rectangle', 'custom'] as ShapeOption[]).map((opt) => (
+              <TouchableOpacity
+                key={opt}
+                style={[styles.option, shape === opt && styles.selectedOption]}
+                onPress={() => setShape(opt)}
+              >
+                <Text>{opt}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          {shape === 'custom' && (
+            <View style={styles.inputs}>
+              <TextInput
+                placeholder="Width"
+                value={width}
+                onChangeText={setWidth}
+                keyboardType="numeric"
+                style={styles.input}
+              />
+              <TextInput
+                placeholder="Height"
+                value={height}
+                onChangeText={setHeight}
+                keyboardType="numeric"
+                style={styles.input}
+              />
+            </View>
+          )}
+          <View style={styles.actions}>
+            <Button title="Cancel" onPress={onClose} />
+            <Button title="OK" onPress={handleSelect} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  container: {
+    width: '80%',
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 8,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  options: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginBottom: 12,
+  },
+  option: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+  },
+  selectedOption: {
+    backgroundColor: '#eee',
+  },
+  inputs: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginHorizontal: 4,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+});
+

--- a/src/components/SizeSelectorModal.tsx
+++ b/src/components/SizeSelectorModal.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, Button, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { Modal, View, Text, Button, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
 
-export type ShapeOption = 'circle' | 'rectangle' | 'custom';
+export type ShapeType = 'circle' | 'rectangle' | 'custom';
 
 interface SizeSelectorModalProps {
   visible: boolean;
   onClose: () => void;
-  onSelect: (shape: ShapeOption, width: number, height: number) => void;
+  onSelect: (params: { shape: ShapeType; width: number; height: number }) => void;
 }
 
 const DEFAULT_CIRCLE_SIZE = 200;
@@ -14,19 +14,19 @@ const DEFAULT_RECT_WIDTH = 200;
 const DEFAULT_RECT_HEIGHT = 150;
 
 export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSelectorModalProps) {
-  const [shape, setShape] = useState<ShapeOption>('circle');
+  const [shape, setShape] = useState<ShapeType>('circle');
   const [width, setWidth] = useState('');
   const [height, setHeight] = useState('');
 
   const handleSelect = () => {
     if (shape === 'circle') {
-      onSelect('circle', DEFAULT_CIRCLE_SIZE, DEFAULT_CIRCLE_SIZE);
+      onSelect({ shape, width: DEFAULT_CIRCLE_SIZE, height: DEFAULT_CIRCLE_SIZE });
     } else if (shape === 'rectangle') {
-      onSelect('rectangle', DEFAULT_RECT_WIDTH, DEFAULT_RECT_HEIGHT);
+      onSelect({ shape, width: DEFAULT_RECT_WIDTH, height: DEFAULT_RECT_HEIGHT });
     } else {
       const w = parseInt(width, 10) || 0;
       const h = parseInt(height, 10) || 0;
-      onSelect('custom', w, h);
+      onSelect({ shape, width: w, height: h });
     }
     onClose();
   };
@@ -37,7 +37,7 @@ export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSe
         <View style={styles.container}>
           <Text style={styles.title}>Select Size</Text>
           <View style={styles.options}>
-            {(['circle', 'rectangle', 'custom'] as ShapeOption[]).map((opt) => (
+            {(['circle', 'rectangle', 'custom'] as ShapeType[]).map((opt) => (
               <TouchableOpacity
                 key={opt}
                 style={[styles.option, shape === opt && styles.selectedOption]}
@@ -50,24 +50,24 @@ export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSe
           {shape === 'custom' && (
             <View style={styles.inputs}>
               <TextInput
-                placeholder="Width"
+                style={styles.input}
+                keyboardType="numeric"
                 value={width}
                 onChangeText={setWidth}
-                keyboardType="numeric"
-                style={styles.input}
+                placeholder="Width"
               />
               <TextInput
-                placeholder="Height"
+                style={styles.input}
+                keyboardType="numeric"
                 value={height}
                 onChangeText={setHeight}
-                keyboardType="numeric"
-                style={styles.input}
+                placeholder="Height"
               />
             </View>
           )}
           <View style={styles.actions}>
             <Button title="Cancel" onPress={onClose} />
-            <Button title="OK" onPress={handleSelect} />
+            <Button title="Create" onPress={handleSelect} />
           </View>
         </View>
       </View>
@@ -78,9 +78,9 @@ export default function SizeSelectorModal({ visible, onClose, onSelect }: SizeSe
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgba(0,0,0,0.5)',
   },
   container: {
     width: '80%',
@@ -88,31 +88,16 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 8,
   },
-  title: {
-    fontSize: 18,
-    marginBottom: 12,
-    textAlign: 'center',
-  },
-  options: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    marginBottom: 12,
-  },
+  title: { fontSize: 18, marginBottom: 12, textAlign: 'center' },
+  options: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 12 },
   option: {
-    paddingVertical: 8,
-    paddingHorizontal: 12,
+    padding: 8,
     borderWidth: 1,
     borderColor: '#ccc',
     borderRadius: 4,
   },
-  selectedOption: {
-    backgroundColor: '#eee',
-  },
-  inputs: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 12,
-  },
+  selectedOption: { backgroundColor: '#def' },
+  inputs: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 },
   input: {
     flex: 1,
     borderWidth: 1,
@@ -121,9 +106,5 @@ const styles = StyleSheet.create({
     padding: 8,
     marginHorizontal: 4,
   },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-  },
+  actions: { flexDirection: 'row', justifyContent: 'space-between' },
 });
-

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -18,7 +18,7 @@ export type RootStackParamList = {
         height?: number;
       }
     | undefined;
-  Guide: undefined;
+  Guide: { width?: number; height?: number; beadSize?: number } | undefined;
   Preview: undefined;
   ARPreview: undefined;
   Settings: undefined;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -10,7 +10,14 @@ import SettingsScreen from '@screens/SettingsScreen';
 
 export type RootStackParamList = {
   Home: undefined;
-  Editor: { id?: string } | undefined;
+  Editor:
+    | {
+        id?: string;
+        shape?: 'circle' | 'rectangle' | 'custom';
+        width?: number;
+        height?: number;
+      }
+    | undefined;
   Guide: undefined;
   Preview: undefined;
   ARPreview: undefined;

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Image, StyleSheet, Button, ActivityIndicator } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+  Button,
+  ActivityIndicator,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@navigation/AppNavigator';
+import SizeSelectorModal, { ShapeType } from '@components/SizeSelectorModal';
 
 interface DesignItem {
   id: string;
@@ -15,6 +25,7 @@ export default function DashboardScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [designs, setDesigns] = useState<DesignItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
     const fetchDesigns = async () => {
@@ -31,6 +42,11 @@ export default function DashboardScreen() {
 
     fetchDesigns();
   }, []);
+
+  const handleCreate = (params: { shape: ShapeType; width: number; height: number }) => {
+    setModalVisible(false);
+    navigation.navigate('Editor', params);
+  };
 
   const renderItem = ({ item }: { item: DesignItem }) => (
     <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('Editor', { id: item.id })}>
@@ -53,8 +69,13 @@ export default function DashboardScreen() {
         />
       )}
       <View style={styles.createButton}>
-        <Button title="Create New Design" onPress={() => navigation.navigate('Editor')} />
+        <Button title="Create New Design" onPress={() => setModalVisible(true)} />
       </View>
+      <SizeSelectorModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        onSelect={handleCreate}
+      />
     </View>
   );
 }

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -13,6 +13,7 @@ import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@navigation/AppNavigator';
+import useOfflineStorage from '@hooks/useOffline';
 import SizeSelectorModal, { ShapeType } from '@components/SizeSelectorModal';
 
 interface DesignItem {
@@ -26,6 +27,11 @@ export default function DashboardScreen() {
   const [designs, setDesigns] = useState<DesignItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
+  const {
+    data: cachedDesigns,
+    save: saveCachedDesigns,
+    loading: offlineLoading,
+  } = useOfflineStorage<DesignItem[]>('designs');
 
   useEffect(() => {
     const fetchDesigns = async () => {
@@ -33,6 +39,7 @@ export default function DashboardScreen() {
       try {
         const response = await axios.get<DesignItem[]>('/designs');
         setDesigns(response.data);
+        saveCachedDesigns(response.data);
       } catch (err) {
         console.error(err);
       } finally {
@@ -41,7 +48,13 @@ export default function DashboardScreen() {
     };
 
     fetchDesigns();
-  }, []);
+  }, [saveCachedDesigns]);
+
+  useEffect(() => {
+    if (!offlineLoading && cachedDesigns && designs.length === 0) {
+      setDesigns(cachedDesigns);
+    }
+  }, [cachedDesigns, offlineLoading, designs.length]);
 
   const handleCreate = (params: { shape: ShapeType; width: number; height: number }) => {
     setModalVisible(false);
@@ -57,7 +70,7 @@ export default function DashboardScreen() {
 
   return (
     <View style={styles.container}>
-      {loading ? (
+      {(loading || offlineLoading) && designs.length === 0 ? (
         <ActivityIndicator size="large" />
       ) : (
         <FlatList

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -8,7 +8,7 @@ type EditorRouteProp = RouteProp<RootStackParamList, 'Editor'>;
 
 export default function EditorScreen() {
   const route = useRoute<EditorRouteProp>();
-  const { id } = route.params || {};
+  const { id, shape, width, height } = route.params || {};
 
   const onImageSelected = (uri: string) => {
     console.log('Selected image:', uri);
@@ -54,6 +54,11 @@ export default function EditorScreen() {
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>Editor Screen</Text>
       {id && <Text>Design ID: {id}</Text>}
+      {shape && (
+        <Text>
+          Shape: {shape} ({width}x{height})
+        </Text>
+      )}
       <Button title="Add Image" onPress={handleAddImage} />
     </View>
   );

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View, Text, Button, Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import { RouteProp, useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@navigation/AppNavigator';
 
 type EditorRouteProp = RouteProp<RootStackParamList, 'Editor'>;
@@ -9,6 +10,11 @@ type EditorRouteProp = RouteProp<RootStackParamList, 'Editor'>;
 export default function EditorScreen() {
   const route = useRoute<EditorRouteProp>();
   const { id, shape, width, height } = route.params || {};
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const designWidth = width ?? 210;
+  const designHeight = height ?? 297;
+  const beadSize = 5;
 
   const onImageSelected = (uri: string) => {
     console.log('Selected image:', uri);
@@ -56,10 +62,20 @@ export default function EditorScreen() {
       {id && <Text>Design ID: {id}</Text>}
       {shape && (
         <Text>
-          Shape: {shape} ({width}x{height})
+          Shape: {shape} ({designWidth}x{designHeight})
         </Text>
       )}
       <Button title="Add Image" onPress={handleAddImage} />
+      <Button
+        title="View Bead Guide"
+        onPress={() =>
+          navigation.navigate('Guide', {
+            width: designWidth,
+            height: designHeight,
+            beadSize,
+          })
+        }
+      />
     </View>
   );
 }

--- a/src/screens/GuideScreen.tsx
+++ b/src/screens/GuideScreen.tsx
@@ -1,10 +1,39 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { RootStackParamList } from '@navigation/AppNavigator';
+import { calculateBeadGuide } from '@utils/beadGuide';
+
+type GuideRouteProp = RouteProp<RootStackParamList, 'Guide'>;
 
 export default function GuideScreen() {
+  const route = useRoute<GuideRouteProp>();
+  const {
+    width = 210,
+    height = 297,
+    beadSize = 5,
+  } = route.params || {};
+
+  const guide = calculateBeadGuide(width, height, beadSize);
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Guide Screen (WIP)</Text>
+    <View style={styles.container}>
+      <View style={styles.overlay} pointerEvents="none">
+        <Text style={styles.text}>Rows: {guide.rows}</Text>
+        <Text style={styles.text}>Columns: {guide.columns}</Text>
+        <Text style={styles.text}>Total Beads: {guide.neededBeads}</Text>
+        <Text style={styles.text}>Estimated Packs: {guide.packs}</Text>
+      </View>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    padding: 12,
+    borderRadius: 8,
+  },
+  text: { color: '#fff', fontSize: 16, marginVertical: 2 },
+});

--- a/src/screens/PreviewScreen.tsx
+++ b/src/screens/PreviewScreen.tsx
@@ -1,10 +1,57 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Button, Linking, Share } from 'react-native';
+import QrCodeButton from '@components/QrCodeButton';
+import { exportToPdf, Layer } from '@services/exportService';
 
 export default function PreviewScreen() {
+  const [pdfPath, setPdfPath] = useState<string | null>(null);
+
+  const handleExport = async () => {
+    const layers: Layer[] = [
+      {
+        type: 'text',
+        text: 'Sample Design',
+        x: 72,
+        y: 700,
+        color: '#000000',
+        fontSize: 24,
+      },
+    ];
+
+    try {
+      const path = await exportToPdf(layers);
+      setPdfPath(path);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleOpen = () => {
+    if (pdfPath) {
+      Linking.openURL(`file://${pdfPath}`);
+    }
+  };
+
+  const handleShare = () => {
+    if (pdfPath) {
+      Share.share({ url: `file://${pdfPath}` });
+    }
+  };
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Preview Screen (WIP)</Text>
+      <Button title="Export to PDF" onPress={handleExport} />
+      {pdfPath && (
+        <View style={{ marginTop: 16, alignItems: 'center' }}>
+          <QrCodeButton url={`file://${pdfPath}`} onPress={handleOpen} />
+          <View style={{ marginTop: 8 }}>
+            <Button title="Open PDF" onPress={handleOpen} />
+          </View>
+          <View style={{ marginTop: 8 }}>
+            <Button title="Share PDF" onPress={handleShare} />
+          </View>
+        </View>
+      )}
     </View>
   );
 }

--- a/src/screens/PreviewScreen.tsx
+++ b/src/screens/PreviewScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Button, Linking, Share } from 'react-native';
+import { View, Button, Linking, Share } from 'react-native';
 import QrCodeButton from '@components/QrCodeButton';
 import { exportToPdf, Layer } from '@services/exportService';
 


### PR DESCRIPTION
## Summary
- add a reusable `SizeSelectorModal` component
- choose width/height defaults for circle and rectangle
- only render TextInput fields when custom size is selected
- update select handler to use defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bbc44903c832baeaba08ac14bcc5e