### PR TITLE
Add .gitignore for Node/React Native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Node.js dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# React Native specific
+.android/
+.ios/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+


### PR DESCRIPTION
## Summary
- add a new `.gitignore` with standard entries for Node and React Native projects

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bc53380e8832b94a1044ef7d53ab9