### PR TITLE
Fix unused import in PreviewScreen

### DIFF
--- a/src/screens/PreviewScreen.tsx
+++ b/src/screens/PreviewScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Button, Linking, Share } from 'react-native';
+import { View, Button, Linking, Share } from 'react-native';
 import QrCodeButton from '@components/QrCodeButton';
 import { exportToPdf, Layer } from '@services/exportService';
 


### PR DESCRIPTION
## Summary
- remove unused `Text` import from `PreviewScreen`

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686bc5331b2c832ba1d38aad2e3473b7