### PR TITLE
Fix offline cache usage in dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "@types/jest": "^29.5.2",
     "@types/react-native": "^0.73.11",
     "@commitlint/cli": "^18.4.0",
-    "@commitlint/config-conventional": "^18.4.0",
+    "@commitlint/config-conventional": "^18.4.0"
   }
 }

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -50,10 +50,11 @@ export default function DashboardScreen() {
     fetchDesigns();
   }, [saveCachedDesigns]);
 
-  const handleCreate = (params: { shape: ShapeType; width: number; height: number }) => {
-    setModalVisible(false);
-    navigation.navigate('Editor', params);
-  };
+  useEffect(() => {
+    if (!offlineLoading && cachedDesigns && designs.length === 0) {
+      setDesigns(cachedDesigns);
+    }
+  }, [cachedDesigns, offlineLoading, designs.length]);
 
   const handleCreate = (params: { shape: ShapeType; width: number; height: number }) => {
     setModalVisible(false);


### PR DESCRIPTION
## Summary
- remove stray comma from `package.json`
- load cached designs in `DashboardScreen`
- remove duplicate `handleCreate` definition

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686bc5344c0c832ba9b284943d9370bf